### PR TITLE
Add autojoining function

### DIFF
--- a/SteamRelayBot/App.config
+++ b/SteamRelayBot/App.config
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
+    <section name="autojoinGroupChats" type="SteamRelayBot.AutojoinGroupChatConfigurationSection, SteamRelayBot" requirePermission="false" />
   </configSections>
+  <autojoinGroupChats>
+    <steamIDs>
+      <add steamID="" />
+    </steamIDs>
+  </autojoinGroupChats>
   <appSettings>
-    <add key="user" value="relaybot"/>
+    <add key="user" value=""/>
     <add key="password" value=""/>
     <add key="apikey" value=""/>
   </appSettings>

--- a/SteamRelayBot/ConfigElements.cs
+++ b/SteamRelayBot/ConfigElements.cs
@@ -1,0 +1,51 @@
+﻿using System.Configuration;
+
+namespace SteamRelayBot
+{
+    class GroupChatElement : ConfigurationElement
+    {
+        [ConfigurationProperty("steamID", IsKey = true, IsRequired = true)]
+        public string SteamID
+        {
+            get { return (string)this["steamID"]; }
+        }
+    }
+
+    class GroupChatElementCollection : ConfigurationElementCollection
+    {
+        public GroupChatElement this[int index]
+        {
+            get
+            {
+                return (GroupChatElement)BaseGet(index);
+            }
+            set
+            {
+                if (BaseGet(index) != null)
+                {
+                    BaseRemoveAt(index);
+                }
+                BaseAdd(index, value);
+            }
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new GroupChatElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((GroupChatElement)element).SteamID;
+        }
+    }
+
+    class AutojoinGroupChatConfigurationSection : ConfigurationSection
+    {
+        [ConfigurationProperty("steamIDs")]
+        public GroupChatElementCollection SteamIDs
+        {
+            get { return (GroupChatElementCollection)this["steamIDs"]; }
+        }
+    }
+}

--- a/SteamRelayBot/SteamRelayBot.csproj
+++ b/SteamRelayBot/SteamRelayBot.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Commands\Stock.cs" />
     <Compile Include="Commands\Trivia.cs" />
     <Compile Include="Commands\UrbanDictionary.cs" />
+    <Compile Include="ConfigElements.cs" />
     <Compile Include="DataSet1.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
You can now specify 64bit IDs of groups you want the bot to join automatically as soon as it's connected.

Use App.config to set the IDs.
